### PR TITLE
fix missing param in section 'avoid side effects part 1' in 'good example

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ function toBase64(text:string):string {
   return btoa(text);
 }
 
-const encodedName = toBase64();
+const encodedName = toBase64(name);
 
 console.log(name);
 ```


### PR DESCRIPTION
Added missing param in https://github.com/labs42io/clean-code-typescript#avoid-side-effects-part-1 in good example. 
