### PR TITLE
Fix addItemToCart example to return CartItem array instead of object

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ function addItemToCart(cart: CartItem[], item:Item):void {
 
 ```ts
 function addItemToCart(cart: CartItem[], item:Item):CartItem[] {
-  return {...cart, { item, date: Date.now() }};
+  return [...cart, { item, date: Date.now() }];
 };
 ```
 


### PR DESCRIPTION
Currently the good code example, `addItemToCart(...)` ,  for Avoid Side Effects (part 2) in Functions would cause a compilation error due to the method definition claiming it should return an array of CartItem's, yet an object is what is actually returned. 

I fixed this :) 