### PR TITLE
add const assertions in typescript 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,14 +1199,26 @@ interface Config {
 }
 ```
 
-case of Array, you can create a read-only array by using `ReadonlyArray<T>`.
+Case of Array, you can create a read-only array by using `ReadonlyArray<T>`.
 do not allow changes such as `push()` and `fill()`, but can use features such as `concat()` and `slice()` that do not change the value.
+
+**Bad:**
+
+```ts
+const array: Array<number> = [ 1, 3, 5 ];
+array = []; // error
+array.push(100); // array will updated
+```
+
+**Good:**
 
 ```ts
 const array: ReadonlyArray<number> = [ 1, 3, 5 ];
+array = []; // error
+array.push(100); // error
 ```
 
-declaring read-only arguments in [TypeScript 3.4 is a bit easier](https://github.com/microsoft/TypeScript/wiki/What's-new-in-TypeScript#improvements-for-readonlyarray-and-readonly-tuples).
+Declaring read-only arguments in [TypeScript 3.4 is a bit easier](https://github.com/microsoft/TypeScript/wiki/What's-new-in-TypeScript#improvements-for-readonlyarray-and-readonly-tuples).
 
 ```ts
 function hoge(args: readonly string[]) {
@@ -1214,25 +1226,41 @@ function hoge(args: readonly string[]) {
 }
 ```
 
-TypeScript 3.4 introduces a new construct for literal values called [const assertions](https://github.com/microsoft/TypeScript/wiki/What's-new-in-TypeScript#const-assertions).
+Prefer [const assertions](https://github.com/microsoft/TypeScript/wiki/What's-new-in-TypeScript#const-assertions) for literal values
 
-- no literal types in that expression should be widened (e.g. no going from "hello" to string)
-- object literals get readonly properties
-- array literals become readonly tuples
+**Bad:**
 
 ```ts
-// can not assign except the "word" string
-let hello = 'world' as const;
-hello = 'world'; // success
-hello = 'world'; // error
+// const object
+const config = {
+  hello: 'world'
+};
+config.hello = 'world'; // value is written
 
+// const array
+const array  = [ 1, 3, 5 ];
+array[0] = 10; // value is written
+
+// writable objects is returned
+function readonlyData(value: number) {
+  return { value };
+}
+const result = readonlyData(100);
+result.value = 200; // value is written
+```
+
+**Good:**
+
+```ts
 // read-only object
 const config = {
   hello: 'world'
 } as const;
+config.hello = 'world'; // error
 
 // read-only array
 const array  = [ 1, 3, 5 ] as const;
+array[0] = 10; // error
 
 // You can return read-only objects
 function readonlyData(value: number) {

--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,7 @@ do not allow changes such as `push()` and `fill()`, but can use features such as
 **Bad:**
 
 ```ts
-const array: Array<number> = [ 1, 3, 5 ];
+const array: number[] = [ 1, 3, 5 ];
 array = []; // error
 array.push(100); // array will updated
 ```
@@ -1226,27 +1226,26 @@ function hoge(args: readonly string[]) {
 }
 ```
 
-Prefer [const assertions](https://github.com/microsoft/TypeScript/wiki/What's-new-in-TypeScript#const-assertions) for literal values
+Prefer [const assertions](https://github.com/microsoft/TypeScript/wiki/What's-new-in-TypeScript#const-assertions) for literal values.
 
 **Bad:**
 
 ```ts
-// const object
 const config = {
   hello: 'world'
 };
-config.hello = 'world'; // value is written
+config.hello = 'world'; // value is changed
 
-// const array
 const array  = [ 1, 3, 5 ];
-array[0] = 10; // value is written
+array[0] = 10; // value is changed
 
 // writable objects is returned
 function readonlyData(value: number) {
   return { value };
 }
+
 const result = readonlyData(100);
-result.value = 200; // value is written
+result.value = 200; // value is changed
 ```
 
 **Good:**
@@ -1266,6 +1265,7 @@ array[0] = 10; // error
 function readonlyData(value: number) {
   return { value } as const;
 }
+
 const result = readonlyData(100);
 result.value = 200; // error
 ```

--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,49 @@ interface Config {
 }
 ```
 
+case of Array, you can create a read-only array by using `ReadonlyArray<T>`.
+do not allow changes such as `push()` and `fill()`, but can use features such as `concat()` and `slice()` that do not change the value.
+
+```ts
+const array: ReadonlyArray<number> = [ 1, 3, 5 ];
+```
+
+declaring read-only arguments in [TypeScript 3.4 is a bit easier](https://github.com/microsoft/TypeScript/wiki/What's-new-in-TypeScript#improvements-for-readonlyarray-and-readonly-tuples).
+
+```ts
+function hoge(args: readonly string[]) {
+  args.push(1); // error
+}
+```
+
+TypeScript 3.4 introduces a new construct for literal values called [const assertions](https://github.com/microsoft/TypeScript/wiki/What's-new-in-TypeScript#const-assertions).
+
+- no literal types in that expression should be widened (e.g. no going from "hello" to string)
+- object literals get readonly properties
+- array literals become readonly tuples
+
+```ts
+// can not assign except the "word" string
+let hello = 'world' as const;
+hello = 'world'; // success
+hello = 'world'; // error
+
+// read-only object
+const config = {
+  hello: 'world'
+} as const;
+
+// read-only array
+const array  = [ 1, 3, 5 ] as const;
+
+// You can return read-only objects
+function readonlyData(value: number) {
+  return { value } as const;
+}
+const result = readonlyData(100);
+result.value = 200; // error
+```
+
 **[⬆ back to top](#table-of-contents)**
 
 ### type vs. interface

--- a/README.md
+++ b/README.md
@@ -1223,7 +1223,7 @@ interface Config {
 
 //...
 
-type Shape {
+type Shape = {
   // ...
 }
 ```
@@ -1232,11 +1232,11 @@ type Shape {
 
 ```ts
 
-type EmailConfig {
+type EmailConfig = {
   // ...
 }
 
-type DbConfig {
+type DbConfig = {
   // ...
 }
 
@@ -2396,8 +2396,8 @@ const Artists = ['ACDC', 'Led Zeppelin', 'The Beatles'];
 function eraseDatabase() {}
 function restore_database() {}
 
-type animal { /* ... */ }
-type Container { /* ... */ }
+type animal = { /* ... */ }
+type Container = { /* ... */ }
 ```
 
 **Good:**
@@ -2412,8 +2412,8 @@ const ARTISTS = ['ACDC', 'Led Zeppelin', 'The Beatles'];
 function eraseDatabase() {}
 function restoreDatabase() {}
 
-type Animal { /* ... */ }
-type Container { /* ... */ }
+type Animal = { /* ... */ }
+type Container = { /* ... */ }
 ```
 
 Prefer using `PascalCase` for class, interface, type and namespace names.  


### PR DESCRIPTION
#5 

added const assertions and read-only Array to [Prefer immutability](https://github.com/labs42io/clean-code-typescript#prefer-immutability) section.
