### PR TITLE
Change implied variable name for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,7 +878,7 @@ function isEmailUsed(email: string): boolean {
   // ...
 }
 
-if (!isEmailUsed(node)) {
+if (!isEmailUsed(email)) {
   // ...
 }
 ```


### PR DESCRIPTION
The good example passes a variable with a different, less understandable name than the bad example.

The change is about the function name, not the variable name, so for consistency this should be `email` instead of `node`