### PR TITLE
Adding terminology for magic literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ setTimeout(restart, 86400000);
 **Good:**
 
 ```ts
-// Declare them as capitalized symbolic constants.
+// Declare them as capitalized named constants.
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000; // 86400000
 
 setTimeout(restart, MILLISECONDS_PER_DAY);

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ function getUser(): User;
 
 **[⬆ back to top](#table-of-contents)**
 
-### Use searchable names
+### Use searchable names / Avoid Magic Literals
 
-We will read more code than we will ever write. It's important that the code we do write must be readable and searchable. By *not* naming variables that end up being meaningful for understanding our program, we hurt our readers. Make your names searchable. Tools like [ESLint](https://typescript-eslint.io/) can help identify unnamed constants.
+We will read more code than we will ever write. It's important that the code we do write must be readable and searchable. By *not* naming variables that end up being meaningful for understanding our program, we hurt our readers. Make your names searchable. Tools like [ESLint](https://typescript-eslint.io/) can help identify magic literals.
 
 **Bad:**
 
@@ -131,7 +131,7 @@ setTimeout(restart, 86400000);
 **Good:**
 
 ```ts
-// Declare them as capitalized named constants.
+// Declare them as capitalized symbolic constants.
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000; // 86400000
 
 setTimeout(restart, MILLISECONDS_PER_DAY);

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ function getUser(): User;
 
 **[⬆ back to top](#table-of-contents)**
 
-### Use searchable names / Avoid Magic Literals
+### Use searchable names
 
-We will read more code than we will ever write. It's important that the code we do write must be readable and searchable. By *not* naming variables that end up being meaningful for understanding our program, we hurt our readers. Make your names searchable. Tools like [ESLint](https://typescript-eslint.io/) can help identify magic literals.
+We will read more code than we will ever write. It's important that the code we do write must be readable and searchable. By *not* naming variables that end up being meaningful for understanding our program, we hurt our readers. Make your names searchable. Tools like [ESLint](https://typescript-eslint.io/) can help identify unnamed constants (also known as magic strings and magic numbers).
 
 **Bad:**
 


### PR DESCRIPTION
Terminology for magic literals might be beneficial, in a sense that will make a strong impression to people and will be remembered when writing/reviewing code. 

Also allows easier communication between peers, since the terminology used is an industry standard (everybody will know what the discussion is about, when it comes to _magic literals_, _magic numbers_, _magic strings_).