### PR TITLE
Adding recommendation for constructor arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,14 @@ class Dashboard {
 
 **[⬆ back to top](#table-of-contents)**
 
+### Class constructor arguments (4 or fewer)
+
+Having constructors with a vast amount of parameters can lead to chaotic dependencies or result to very complex client code that would be required in order to build all of these parameters. The recommendation is to have constructors with 4 or fewer arguments, as humans tend to be able to hold 4 things in their head at once *(Susan Weinschenk, 100 Things Every Designer Needs to Know about People, 48)*.
+
+If the use case is such that your object is complex enough to possibly require more than 4 constructor parameters, evaluate using the *[Builder](https://refactoring.guru/design-patterns/builder)* Creational Design Pattern instead.  
+
+**[⬆ back to top](#table-of-contents)**
+
 ### High cohesion and low coupling
 
 Cohesion defines the degree to which class members are related to each other. Ideally, all fields within a class should be used by each method.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ setTimeout(restart, 86400000);
 **Good:**
 
 ```ts
-// Declare them as capitalized symbolic constants.
+// Declare them as capitalized named constants.
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000; // 86400000
 
 setTimeout(restart, MILLISECONDS_PER_DAY);

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ function getUser(): User;
 
 **[⬆ back to top](#table-of-contents)**
 
-### Use searchable names
+### Use searchable names / Avoid Magic Literals
 
-We will read more code than we will ever write. It's important that the code we do write must be readable and searchable. By *not* naming variables that end up being meaningful for understanding our program, we hurt our readers. Make your names searchable. Tools like [ESLint](https://typescript-eslint.io/) can help identify unnamed constants.
+We will read more code than we will ever write. It's important that the code we do write must be readable and searchable. By *not* naming variables that end up being meaningful for understanding our program, we hurt our readers. Make your names searchable. Tools like [ESLint](https://typescript-eslint.io/) can help identify magic literals.
 
 **Bad:**
 
@@ -131,7 +131,7 @@ setTimeout(restart, 86400000);
 **Good:**
 
 ```ts
-// Declare them as capitalized named constants.
+// Declare them as capitalized symbolic constants.
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000; // 86400000
 
 setTimeout(restart, MILLISECONDS_PER_DAY);

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ function getUser(): User;
 
 **[⬆ back to top](#table-of-contents)**
 
-### Use searchable names / Avoid Magic Literals
+### Use searchable names
 
-We will read more code than we will ever write. It's important that the code we do write must be readable and searchable. By *not* naming variables that end up being meaningful for understanding our program, we hurt our readers. Make your names searchable. Tools like [ESLint](https://typescript-eslint.io/) can help identify magic literals.
+We will read more code than we will ever write. It's important that the code we do write must be readable and searchable. By *not* naming variables that end up being meaningful for understanding our program, we hurt our readers. Make your names searchable. Tools like [ESLint](https://typescript-eslint.io/) can help identify unnamed constants (also known as magic strings and magic numbers).
 
 **Bad:**
 


### PR DESCRIPTION
- Recommendation for constructor arguments to be 4 or fewer, as humans tend to be able to hold 4 things in their head at once.
- Recommendation for an alternative approach to use the *Builder* design pattern, in case it is a fit for the individual use case.